### PR TITLE
Support for optional params

### DIFF
--- a/js.rake
+++ b/js.rake
@@ -21,8 +21,21 @@ end
 
 def generate_method(name, path)
   compare = /:(.*?)(\/|$)/
-  path.sub!(compare, "' + params.#{$1} + '#{$2}") while path =~ compare
-  return "function #{name}(params){ return '#{path}'}"
+  path.sub!(compare, "' + options.params.#{$1} + '#{$2}") while path =~ compare
+  
+  js_func = %{
+  function #{name}_path(options){
+    if(options && options.data) {
+      var op_params = []
+      for(var key in options.data){
+        op_params.push([key, options.data[key]].join('='));
+      }
+      return '#{path}?' + op_params.join('&');
+    }else {
+      return '#{path}'
+    }
+  }}
+  return js_func
 end
 
 def generate_routes_for_rails_2

--- a/js.rake
+++ b/js.rake
@@ -21,7 +21,7 @@ end
 
 def generate_method(name, path)
   compare = /:(.*?)(\/|$)/
-  path.sub!(compare, "' + options.params.#{$1} + '#{$2}") while path =~ compare
+  path.sub!(compare, "' + params.#{$1} + '#{$2}") while path =~ compare
   
   js_func = %{
   function #{name}_path(options){
@@ -30,8 +30,13 @@ def generate_method(name, path)
       for(var key in options.data){
         op_params.push([key, options.data[key]].join('='));
       }
+      var params = options.params;
       return '#{path}?' + op_params.join('&');
+    }else if(options && options.params) {
+      var params = options.params;
+      return '#{path}'
     }else {
+      var params = options;
       return '#{path}'
     }
   }}


### PR DESCRIPTION
Makes this possible

```
admin_community_path({params : {id : 2}, data : {per_page : 25}});

=> "/admin/communities/2?per_page=25"
```

The old convention still works so that users won't have to troll through the code and change any previously called routes.

```
admin_community_path({id : 2});

=> "/admin/communities/2"
```
